### PR TITLE
fix: restore proxy detection

### DIFF
--- a/script/mini_backend.js
+++ b/script/mini_backend.js
@@ -98,8 +98,6 @@ function saveJSONToServer() {
 
 
 function determineProxySettings() {
-    return '';
-
     if (window.location.href.indexOf('.developerakademie.com') > -1) {
         return '';
     } else {


### PR DESCRIPTION
## Summary
- restore proxy detection logic in mini_backend

## Testing
- `node --check script/mini_backend.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e773f8788327891a6e2b9e6ef548